### PR TITLE
Add multi-agent forecasting system skeleton

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -8,4 +8,17 @@ OPENAI_API_KEY=1234567890
 EXA_API_KEY=1234567890
 ASKNEWS_CLIENT_ID=1234567890
 ASKNEWS_SECRET=1234567890
+# Optional AskNews tuning (committee engine uses a single combined call)
+ASKNEWS_STRATEGY=news knowledge
+ASKNEWS_N_ARTICLES=10
+# How to join multiple queries into one combined AskNews query (default: " OR ")
+# ASKNEWS_COMBINE_JOINER= OR 
 ANTHROPIC_API_KEY=1234567890
+
+# Committee engine (bot/) real LLM agents
+# If unset, the committee uses deterministic stub agents (no API calls)
+COMMITTEE_LLM_MODELS=
+# e.g. COMMITTEE_LLM_MODELS="openrouter/gpt-4.1-mini, openrouter/claude-3.5-sonnet"
+COMMITTEE_LLM_TEMPERATURE=
+COMMITTEE_LLM_TIMEOUT=40
+COMMITTEE_LLM_TRIES=2

--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,6 @@ cython_debug/
 
 # MacOS
 .DS_Store
+
+# Logs
+logs

--- a/bot/adapter.py
+++ b/bot/adapter.py
@@ -1,0 +1,181 @@
+"""Adapter to use the local `bot/` multi-agent workflow
+within the `forecasting_tools` ForecastBot interface.
+
+This lets you run the committee-based forecasts while
+still benefiting from Metaculus question retrieval,
+aggregation, and posting provided by forecasting_tools.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Sequence
+
+from forecasting_tools import (
+    BinaryQuestion,
+    ForecastBot,
+    MetaculusQuestion,
+    MultipleChoiceQuestion,
+    NumericDistribution,
+    NumericQuestion,
+    Percentile,
+    PredictedOption,
+    PredictedOptionList,
+    ReasonedPrediction,
+)
+
+from .llm_calls import LLMAgent, default_agent_committee
+from .binary import get_binary_forecast
+from .multiple_choice import get_multiple_choice_forecast
+from .numeric import get_numeric_forecast
+from .search import integrated_research
+
+logger = logging.getLogger(__name__)
+
+
+class CommitteeForecastBot(ForecastBot):
+    """ForecastBot implementation backed by the local committee workflow.
+
+    This replaces LLM prompting with the deterministic, multi-agent
+    implementation under `bot/`, but preserves the higher-level orchestration
+    (question fetching, aggregation, reporting, posting to Metaculus).
+    """
+
+    def __init__(
+        self,
+        *,
+        agents: Sequence[LLMAgent] | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._agents: List[LLMAgent] = (
+            list(agents) if agents is not None else default_agent_committee()
+        )
+        logger.info(
+            "CommitteeForecastBot initialized with %s agents: %s",
+            len(self._agents),
+            ", ".join(a.name for a in self._agents),
+        )
+
+    async def run_research(self, question: MetaculusQuestion) -> str:  # type: ignore[override]
+        # Minimal, local research using stubbed utilities; formatted as markdown.
+        queries = [
+            f"Historical perspective on: {question.question_text}",
+            f"Current events for: {question.question_text}",
+        ]
+        logger.info(
+            "[Committee] Running integrated research on %s queries for URL %s",
+            len(queries),
+            getattr(question, "page_url", "<unknown>"),
+        )
+        # Explicitly log the two initial queries inferred from the URL/context
+        if queries:
+            logger.info("[Committee] Initial queries inferred from URL/context:")
+            for q in queries:
+                logger.info("[Committee]   - %s", q)
+        logger.debug("[Committee] Research queries: %s", queries)
+        research = await integrated_research(queries)
+        logger.info(
+            "[Committee] Integrated research collected (%s chars)", len(research)
+        )
+        header = "Here are the scoped queries used for integrated research:\n" + "\n".join(
+            f"- {q}" for q in queries
+        )
+        return f"{header}\n\n{research}"
+
+    async def summarize_research(self, question: MetaculusQuestion, research: str) -> str:  # type: ignore[override]
+        # Use parent summarization, but log the full summary for traceability
+        summary = await super().summarize_research(question, research)
+        try:
+            logger.info(
+                "[Committee] Research summary (%s chars) for %s:\n%s",
+                len(summary),
+                getattr(question, "page_url", "<unknown>"),
+                summary,
+            )
+        except Exception:
+            # Avoid crashing if summary is not a string or encoding issues occur
+            logger.info("[Committee] Research summary logged (content omitted due to formatting error)")
+        return summary
+
+    async def _run_forecast_on_binary(
+        self, question: BinaryQuestion, research: str
+    ) -> ReasonedPrediction[float]:  # type: ignore[override]
+        logger.info(
+            "[Committee] Forecasting binary question (agents=%s): %s",
+            len(self._agents),
+            question.question_text,
+        )
+        prob = await get_binary_forecast(question.question_text, self._agents)
+        logger.info("[Committee] Aggregated binary probability (decimal): %.4f", prob)
+        reasoning = (
+            f"Committee of {len(self._agents)} agents produced an aggregated probability: "
+            f"{round(prob * 100, 2)}%."
+        )
+        return ReasonedPrediction(prediction_value=prob, reasoning=reasoning)
+
+    async def _run_forecast_on_multiple_choice(
+        self, question: MultipleChoiceQuestion, research: str
+    ) -> ReasonedPrediction[PredictedOptionList]:  # type: ignore[override]
+        logger.info(
+            "[Committee] Forecasting multiple-choice (agents=%s) options=%s",
+            len(self._agents),
+            question.options,
+        )
+        probs = await get_multiple_choice_forecast(
+            question.question_text, question.options, self._agents
+        )
+        predicted = PredictedOptionList(
+            predicted_options=[
+                PredictedOption(option_name=name, probability=float(p))
+                for name, p in zip(question.options, probs)
+            ]
+        )
+        logger.info(
+            "[Committee] Aggregated MC probabilities: %s",
+            {name: round(float(p), 4) for name, p in zip(question.options, probs)},
+        )
+        reasoning_lines = [
+            f"- {name}: {round(p * 100, 1)}%"
+            for name, p in zip(question.options, probs)
+        ]
+        reasoning = (
+            f"Committee of {len(self._agents)} agents aggregated option probabilities:\n"
+            + "\n".join(reasoning_lines)
+        )
+        return ReasonedPrediction(prediction_value=predicted, reasoning=reasoning)
+
+    async def _run_forecast_on_numeric(
+        self, question: NumericQuestion, research: str
+    ) -> ReasonedPrediction[NumericDistribution]:  # type: ignore[override]
+        # Ask the local numeric workflow to generate a full quantile path (201 points)
+        # based on a small set of guiding percentiles.
+        guiding_percentiles = (10, 25, 50, 75, 90)
+        logger.info(
+            "[Committee] Forecasting numeric (agents=%s) with guiding percentiles %s",
+            len(self._agents),
+            guiding_percentiles,
+        )
+        quantile_values = await get_numeric_forecast(
+            question.question_text, guiding_percentiles, self._agents
+        )
+        # Map the quantile path (values at evenly spaced probabilities) to declared percentiles
+        # used by forecasting_tools. Grid is 0..1 with 201 points => index = int(round(p * 200)).
+        sample_ps = [0.10, 0.20, 0.40, 0.60, 0.80, 0.90]
+        declared = [
+            Percentile(percentile=p, value=float(quantile_values[int(round(p * 200))]))
+            for p in sample_ps
+        ]
+        distribution = NumericDistribution.from_question(declared, question)
+        logger.info(
+            "[Committee] Aggregated numeric distribution samples: %s",
+            {int(p * 100): float(quantile_values[int(round(p * 200))]) for p in sample_ps},
+        )
+        reasoning = (
+            "Committee aggregated numeric distribution (representative percentiles): "
+            + ", ".join(
+                f"P{int(p*100)}={float(quantile_values[int(round(p*200))]):.2f}"
+                for p in sample_ps
+            )
+        )
+        return ReasonedPrediction(prediction_value=distribution, reasoning=reasoning)

--- a/bot/binary.py
+++ b/bot/binary.py
@@ -1,0 +1,61 @@
+"""Binary question forecasting workflow."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import List
+
+import numpy as np
+
+from .llm_calls import LLMAgent
+from .search import integrated_research
+from .utils import (
+    extract_probability_from_response_as_percentage_not_decimal,
+)
+
+
+async def get_binary_forecast(question: str, agents: List[LLMAgent]) -> float:
+    """Forecast a binary question using the multi-step, multi-agent workflow."""
+    # Phase 1: scoping prompts to produce queries
+    historical_prompt = f"Historical perspective on: {question}"
+    current_prompt = f"Current events for: {question}"
+    scope_agent = agents[0]
+    hist_task = asyncio.create_task(
+        scope_agent.generate(historical_prompt, mode="scoping", topic=question)
+    )
+    curr_task = asyncio.create_task(
+        scope_agent.generate(current_prompt, mode="scoping", topic=question)
+    )
+    scoped_queries = (await hist_task).splitlines() + (await curr_task).splitlines()
+
+    # Phase 2: Integrated research
+    research_context = await integrated_research(scoped_queries)
+
+    # Phase 3: Initial forecast from each agent
+    prompt1 = f"Research:\n{research_context}\nQuestion: {question}"
+    initial_tasks = [
+        asyncio.create_task(agent.generate(prompt1, mode="binary"))
+        for agent in agents
+    ]
+    initial_responses = await asyncio.gather(*initial_tasks)
+
+    # Phase 3.5: create peer review map by rotating analyses
+    context_map = initial_responses[1:] + initial_responses[:1]
+
+    # Phase 4: Final synthesis prompts
+    final_tasks = []
+    for agent, peer_context in zip(agents, context_map):
+        final_prompt = (
+            f"Research:\n{research_context}\nPeer analysis:\n{peer_context}\nQuestion: {question}"
+        )
+        final_tasks.append(asyncio.create_task(agent.generate(final_prompt, mode="binary")))
+    final_responses = await asyncio.gather(*final_tasks)
+
+    # Extraction and aggregation
+    probs = [
+        extract_probability_from_response_as_percentage_not_decimal(r)
+        for r in final_responses
+    ]
+    weights = np.array([a.weight for a in agents])
+    aggregate = float(np.sum(weights * probs) / np.sum(weights))
+    return max(0.001, min(0.999, aggregate))

--- a/bot/binary.py
+++ b/bot/binary.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import List
+import logging
 
 import numpy as np
 
@@ -11,51 +12,105 @@ from .llm_calls import LLMAgent
 from .search import integrated_research
 from .utils import (
     extract_probability_from_response_as_percentage_not_decimal,
+    today_iso_utc,
 )
 
+logger = logging.getLogger(__name__)
 
 async def get_binary_forecast(question: str, agents: List[LLMAgent]) -> float:
     """Forecast a binary question using the multi-step, multi-agent workflow."""
+    logger.info(
+        "[Committee][Binary] Starting forecast. Agents=%s | Question='%s'",
+        len(agents),
+        question,
+    )
+    today = today_iso_utc()
     # Phase 1: scoping prompts to produce queries
-    historical_prompt = f"Historical perspective on: {question}"
-    current_prompt = f"Current events for: {question}"
+    historical_prompt = f"Date: {today} (UTC)\nHistorical perspective on: {question}"
+    current_prompt = f"Date: {today} (UTC)\nCurrent events for: {question}"
     scope_agent = agents[0]
+    # Log the two initial queries inferred from the question text
+    logger.info(
+        "[Committee][Binary] Initial scoping queries: '%s' | '%s'",
+        historical_prompt,
+        current_prompt,
+    )
+    logger.debug(
+        "[Committee][Binary] Scoping prompts -> historical='%s' | current='%s'",
+        historical_prompt,
+        current_prompt,
+    )
     hist_task = asyncio.create_task(
         scope_agent.generate(historical_prompt, mode="scoping", topic=question)
     )
     curr_task = asyncio.create_task(
         scope_agent.generate(current_prompt, mode="scoping", topic=question)
     )
-    scoped_queries = (await hist_task).splitlines() + (await curr_task).splitlines()
+    hist = await hist_task
+    curr = await curr_task
+    scoped_queries = hist.splitlines() + curr.splitlines()
+    logger.info(
+        "[Committee][Binary] Scoped %s queries from scoping step",
+        len(scoped_queries),
+    )
+    logger.debug("[Committee][Binary] Scoped queries: %s", scoped_queries)
 
     # Phase 2: Integrated research
     research_context = await integrated_research(scoped_queries)
+    logger.info(
+        "[Committee][Binary] Research context length: %s chars",
+        len(research_context),
+    )
 
     # Phase 3: Initial forecast from each agent
-    prompt1 = f"Research:\n{research_context}\nQuestion: {question}"
+    prompt1 = f"Date: {today} (UTC)\nResearch:\n{research_context}\nQuestion: {question}"
+    logger.debug("[Committee][Binary] Initial prompt:\n%s", prompt1)
     initial_tasks = [
-        asyncio.create_task(agent.generate(prompt1, mode="binary"))
+        asyncio.create_task(agent.generate(prompt1, mode="binary", phase="initial"))
         for agent in agents
     ]
     initial_responses = await asyncio.gather(*initial_tasks)
+    logger.info(
+        "[Committee][Binary] Initial responses collected: %s",
+        len(initial_responses),
+    )
+    logger.debug("[Committee][Binary] Initial responses: %s", initial_responses)
 
     # Phase 3.5: create peer review map by rotating analyses
     context_map = initial_responses[1:] + initial_responses[:1]
+    logger.debug("[Committee][Binary] Peer context map: %s", context_map)
 
     # Phase 4: Final synthesis prompts
     final_tasks = []
     for agent, peer_context in zip(agents, context_map):
         final_prompt = (
-            f"Research:\n{research_context}\nPeer analysis:\n{peer_context}\nQuestion: {question}"
+            f"Date: {today} (UTC)\nResearch:\n{research_context}\nPeer analysis:\n{peer_context}\nQuestion: {question}"
         )
-        final_tasks.append(asyncio.create_task(agent.generate(final_prompt, mode="binary")))
+        final_tasks.append(
+            asyncio.create_task(
+                agent.generate(final_prompt, mode="binary", phase="final")
+            )
+        )
     final_responses = await asyncio.gather(*final_tasks)
+    logger.info(
+        "[Committee][Binary] Final responses collected: %s",
+        len(final_responses),
+    )
+    logger.debug("[Committee][Binary] Final responses: %s", final_responses)
 
     # Extraction and aggregation
     probs = [
         extract_probability_from_response_as_percentage_not_decimal(r)
         for r in final_responses
     ]
+    logger.info("[Committee][Binary] Extracted probs (decimals): %s", probs)
     weights = np.array([a.weight for a in agents])
+    logger.debug("[Committee][Binary] Agent weights: %s", weights.tolist())
     aggregate = float(np.sum(weights * probs) / np.sum(weights))
-    return max(0.001, min(0.999, aggregate))
+    clipped = max(0.001, min(0.999, aggregate))
+    logger.info(
+        "[Committee][Binary] Aggregated (weighted) prob=%.4f | Clipped=%.4f",
+        aggregate,
+        clipped,
+    )
+    return clipped

--- a/bot/forecaster.py
+++ b/bot/forecaster.py
@@ -1,0 +1,35 @@
+"""Per-question-type orchestration for forecasts."""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from .binary import get_binary_forecast
+from .llm_calls import LLMAgent, default_agent_committee
+from .multiple_choice import get_multiple_choice_forecast
+from .numeric import get_numeric_forecast
+
+
+async def forecast_question(question: dict, agents: Sequence[LLMAgent] | None = None):
+    """Route a question dictionary to the appropriate workflow.
+
+    Parameters
+    ----------
+    question: dict
+        A mapping containing ``type`` and other fields depending on the type.
+    agents: Sequence[LLMAgent] | None
+        Optionally override the default agent committee.
+    """
+    agents = list(agents) if agents is not None else default_agent_committee()
+    qtype = question["type"]
+    if qtype == "binary":
+        return await get_binary_forecast(question["text"], agents)
+    if qtype == "multiple_choice":
+        return await get_multiple_choice_forecast(
+            question["text"], question["options"], agents
+        )
+    if qtype == "numeric":
+        return await get_numeric_forecast(
+            question["text"], question.get("percentiles", (10, 25, 50, 75, 90)), agents
+        )
+    raise ValueError(f"Unknown question type: {qtype}")

--- a/bot/llm_calls.py
+++ b/bot/llm_calls.py
@@ -1,0 +1,70 @@
+"""LLM agent abstractions used by the forecasting system.
+
+The real system would interface with multiple model families.  For the
+purposes of this repository the agents produce deterministic pseudo-random
+outputs so the rest of the pipeline can be exercised without external
+API calls.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from dataclasses import dataclass
+from typing import List, Sequence
+
+
+@dataclass
+class LLMAgent:
+    """Simple deterministic agent used for simulation.
+
+    The ``generate`` method returns text matching the expected structure for
+    the different forecasting prompts.  A hash of the prompt and agent name is
+    used to seed a local random generator so results are stable across runs.
+    """
+
+    name: str
+    weight: float = 1.0
+
+    async def generate(self, prompt: str, mode: str, **kwargs) -> str:
+        seed_input = (self.name + mode + prompt).encode()
+        seed = int(hashlib.md5(seed_input).hexdigest()[:8], 16)
+        rnd = random.Random(seed)
+
+        if mode == "scoping":
+            topic = kwargs.get("topic", "query")
+            return f"- {topic} history\n- {topic} recent developments"
+
+        if mode == "binary":
+            prob = rnd.randint(1, 99)
+            return f"Probability: {prob}%"
+
+        if mode == "multiple_choice":
+            n = kwargs.get("n_options", 2)
+            raw = [rnd.random() for _ in range(n)]
+            total = sum(raw)
+            percentages = [round(x / total * 100, 1) for x in raw]
+            joined = ", ".join(f"{p}%" for p in percentages)
+            return f"Probabilities: [{joined}]"
+
+        if mode == "numeric":
+            percentiles: Sequence[int] = kwargs.get(
+                "percentiles", (10, 25, 50, 75, 90)
+            )
+            base = rnd.uniform(0, 100)
+            lines = []
+            for i, p in enumerate(percentiles):
+                value = base + (i + 1) * rnd.uniform(5, 15)
+                lines.append(f"Percentile {p}: {value:.1f}")
+            return "\n".join(lines)
+
+        return ""
+
+
+def default_agent_committee() -> List[LLMAgent]:
+    """Return a default set of three equal-weight agents."""
+    return [
+        LLMAgent("openrouter/claude-sonnet-4"),
+        LLMAgent("openrouter/gpt-5"),
+        LLMAgent("gemini-2.5-pro"),
+    ]

--- a/bot/llm_calls.py
+++ b/bot/llm_calls.py
@@ -1,17 +1,36 @@
 """LLM agent abstractions used by the forecasting system.
 
-The real system would interface with multiple model families.  For the
-purposes of this repository the agents produce deterministic pseudo-random
-outputs so the rest of the pipeline can be exercised without external
-API calls.
+This module now supports two kinds of agents:
+
+- LLMAgent (default, deterministic): a local, deterministic pseudo-agent that
+  produces stable outputs without calling external APIs. Great for offline
+  testing and debugging.
+- RealLLMAgent: a thin wrapper over ``forecasting_tools.GeneralLlm`` that
+  performs real API calls to providers (OpenAI, OpenRouter, Anthropic, etc.)
+  depending on your model string and environment keys. It formats prompts so
+  that outputs match the committee workflow's expected structures.
+
+By default the committee uses the deterministic agents. To enable real API
+calls for the committee engine, set the env var ``COMMITTEE_LLM_MODELS`` to a
+comma-separated list of model identifiers (e.g. "openrouter/gpt-4.1-mini, openai/gpt-4o-mini").
+
+Optional env vars for tuning the real agents:
+- COMMITTEE_LLM_TEMPERATURE (float, default: None)
+- COMMITTEE_LLM_TIMEOUT (int seconds, default: 40)
+- COMMITTEE_LLM_TRIES (int, default: 2)
 """
 
 from __future__ import annotations
 
 import hashlib
+import os
 import random
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+import asyncio
 from typing import List, Sequence
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -30,14 +49,37 @@ class LLMAgent:
         seed_input = (self.name + mode + prompt).encode()
         seed = int(hashlib.md5(seed_input).hexdigest()[:8], 16)
         rnd = random.Random(seed)
+        logger.info(
+            "[Committee][Agent] %s generate() called | mode=%s | seed=%s | kwargs=%s",
+            self.name,
+            mode,
+            seed,
+            kwargs,
+        )
+        # Log the exact prompt sent to this agent
+        logger.info(
+            "[Committee][Agent] %s PROMPT (%s):\n%s",
+            self.name,
+            mode,
+            prompt,
+        )
 
         if mode == "scoping":
             topic = kwargs.get("topic", "query")
-            return f"- {topic} history\n- {topic} recent developments"
+            out = f"- {topic} history\n- {topic} recent developments"
+            # Log the exact response
+            logger.info(
+                "[Committee][Agent] %s RESPONSE (%s):\n%s", self.name, mode, out
+            )
+            return out
 
         if mode == "binary":
             prob = rnd.randint(1, 99)
-            return f"Probability: {prob}%"
+            out = f"Probability: {prob}%"
+            logger.info(
+                "[Committee][Agent] %s RESPONSE (%s):\n%s", self.name, mode, out
+            )
+            return out
 
         if mode == "multiple_choice":
             n = kwargs.get("n_options", 2)
@@ -45,26 +87,376 @@ class LLMAgent:
             total = sum(raw)
             percentages = [round(x / total * 100, 1) for x in raw]
             joined = ", ".join(f"{p}%" for p in percentages)
-            return f"Probabilities: [{joined}]"
+            out = f"Probabilities: [{joined}]"
+            logger.info(
+                "[Committee][Agent] %s RESPONSE (%s):\n%s", self.name, mode, out
+            )
+            return out
 
         if mode == "numeric":
-            percentiles: Sequence[int] = kwargs.get(
-                "percentiles", (10, 25, 50, 75, 90)
-            )
+            percentiles: Sequence[int] = kwargs.get("percentiles", (10, 25, 50, 75, 90))
             base = rnd.uniform(0, 100)
             lines = []
             for i, p in enumerate(percentiles):
                 value = base + (i + 1) * rnd.uniform(5, 15)
                 lines.append(f"Percentile {p}: {value:.1f}")
-            return "\n".join(lines)
+            out = "\n".join(lines)
+            logger.info(
+                "[Committee][Agent] %s RESPONSE (%s):\n%s", self.name, mode, out
+            )
+            return out
 
         return ""
 
 
+@dataclass
+class RealLLMAgent(LLMAgent):
+    """Agent that calls real LLMs via forecasting_tools.GeneralLlm.
+
+    The caller provides the ``name`` as a model identifier understood by
+    forecasting_tools (e.g., "openrouter/gpt-4.1-mini", "openai/gpt-4o-mini").
+    The ``generate`` method wraps the incoming prompt with strict formatting
+    instructions for each mode ("scoping", "binary", "multiple_choice",
+    "numeric") so outputs are compatible with the downstream parsers.
+    """
+
+    temperature: float | None = None
+    timeout: int | None = 40
+    allowed_tries: int = 2
+    _llm: object | None = field(default=None, init=False, repr=False)
+
+    def _is_gemini_model(self) -> bool:
+        """Return True if this agent targets Gemini via google-genai.
+
+        Currently supports: gemini-2.5-flash, gemini-2.5-pro
+        """
+        model = (self.name or "").strip().lower()
+        return model in {"gemini-2.5-flash", "gemini-2.5-pro"}
+
+    def _ensure_llm(self):
+        # Gemini models are handled via google-genai, not GeneralLlm
+        if self._is_gemini_model():
+            return
+        if self._llm is None:
+            try:
+                from forecasting_tools import GeneralLlm
+            except Exception as e:  # noqa: BLE001
+                logger.error(
+                    "[Committee][Agent] Could not import forecasting_tools.GeneralLlm: %s",
+                    e,
+                )
+                raise
+            self._llm = GeneralLlm(
+                model=self.name,
+                temperature=self.temperature,
+                timeout=self.timeout,
+                allowed_tries=self.allowed_tries,
+            )
+
+    def _gemini_invoke_blocking(self, final_prompt: str) -> str:
+        """Synchronous call to Gemini using google-genai.
+
+        Follows the pattern in `gemini_api.py`, but without the google_search tool.
+        Reads the API key from GEMINI_API_KEY_1 (or GOOGLE_API_KEY fallback).
+        """
+        api_keys = [
+            os.getenv("GEMINI_API_KEY_1"),
+            os.getenv("GEMINI_API_KEY_2"),
+            os.getenv("GEMINI_API_KEY_3"),
+            os.getenv("GOOGLE_API_KEY"),
+        ]
+        api_keys = [k for k in api_keys if k]
+        if not api_keys:
+            raise ValueError(
+                "Gemini API key is missing. Set GEMINI_API_KEY_1/2/3 or GOOGLE_API_KEY."
+            )
+        try:
+            from google import genai
+            from google.genai import types
+        except Exception as e:  # noqa: BLE001
+            logger.error("[Committee][Agent] google-genai import failed: %s", e)
+            raise
+
+        last_err: Exception | None = None
+        for key in api_keys:
+            try:
+                client = genai.Client(api_key=key)
+                contents = [
+                    types.Content(
+                        role="user",
+                        parts=[types.Part.from_text(text=final_prompt)],
+                    )
+                ]
+                config = types.GenerateContentConfig(response_mime_type="text/plain")
+
+                full_response = ""
+                try:
+                    for chunk in client.models.generate_content_stream(
+                        model=self.name,
+                        contents=contents,
+                        config=config,
+                    ):
+                        full_response += getattr(chunk, "text", "")
+                except Exception:
+                    # Fallback to non-streaming if streaming fails in this environment
+                    result = client.models.generate_content(
+                        model=self.name, contents=contents, config=config
+                    )
+                    # google-genai returns a response object with .text
+                    full_response = getattr(result, "text", "")
+
+                if full_response:
+                    return full_response
+            except Exception as e:  # noqa: BLE001
+                last_err = e
+                continue
+
+        # If we exhausted keys without success, raise the last error
+        if last_err is not None:
+            raise last_err
+        return ""
+
+    @staticmethod
+    def _wrap_prompt_for_mode(base_prompt: str, mode: str, **kwargs) -> str:
+        """Attach strict output-format instructions on top of the base prompt.
+
+        The base prompt already contains context like Research:/Question:/Peer analysis.
+        We add concise instructions so the output fits our parsers in utils.py,
+        while allowing a richer "initial" reasoning phase that does NOT return
+        the final formatted line (to preserve parser behavior in the final phase).
+        Use kwarg ``phase`` in {"initial", "final"}; default is "final".
+        """
+        phase = str(kwargs.get("phase", "final")).lower()
+
+        if mode == "scoping":
+            topic = kwargs.get("topic") or "the query"
+            return (
+                "You are generating web-search queries for forecasting research.\n"
+                f"Topic: {topic}\n\n"
+                "Return 4-8 concise queries, one per line, each starting with '- '.\n"
+                "Cover a mix of types and tag each query at the start with one of: "
+                "[base-rate], [definition], [contrary], [trend/market].\n"
+                "- [base-rate]: reference classes, historical frequencies, survival/censoring.\n"
+                "- [definition]: resolution criteria, synonyms, edge cases, timeline.\n"
+                "- [contrary]: disconfirming evidence, critiques, failure modes.\n"
+                "- [trend/market]: official statistics, expert/market signals, recent trend.\n"
+                "Do not add any other text.\n\n"
+                f"Context:\n{base_prompt}"
+            )
+
+        if mode == "binary":
+            if phase == "initial":
+                return (
+                    "You are a professional forecaster preparing a forecast.\n"
+                    "Write a brief, structured rationale only (no final probability line).\n"
+                    "Include: (1) Prior/base rate (1-2 sentences), (2) 3-5 key drivers with direction,\n"
+                    "(3) Evidence FOR and AGAINST (at least one contrary point), (4) Status quo baseline,\n"
+                    "(5) Resolution criteria checks, (6) Proposed update description in small steps "
+                    "(e.g., +/- a few percentage points or small log-odds changes).\n"
+                    "Do NOT output any line that starts with 'Probability:' and do NOT end with '%'.\n\n"
+                    f"Context:\n{base_prompt}"
+                )
+            # final
+            return (
+                "You are a professional forecaster. Based on the context, output ONLY one line:\n"
+                "Probability: ZZ%\n"
+                "Where ZZ is an integer or decimal from 0 to 100. Do not include any other text.\n\n"
+                f"Context:\n{base_prompt}"
+            )
+
+        if mode == "multiple_choice":
+            n = int(kwargs.get("n_options", 2))
+            if phase == "initial":
+                return (
+                    "You are a professional forecaster preparing a multi-option forecast.\n"
+                    "Write a brief, structured rationale only (no final probabilities line).\n"
+                    "Include: (1) Baseline/reference shares per option, (2) 3-5 adjustment factors\n"
+                    "with direction, (3) strongest/weakest options with 1-sentence reasons,\n"
+                    "(4) at least one disconfirming consideration, (5) note any residual category risks.\n"
+                    "Do NOT output any line that starts with 'Probabilities:' or percentages in brackets.\n\n"
+                    f"Context:\n{base_prompt}"
+                )
+            # final
+            return (
+                "You are a professional forecaster. Based on the context, output ONLY one line:\n"
+                "Probabilities: [p1%, p2%, ..., pN%]\n"
+                f"Use exactly {n} values in order, percentages summing ~100. Do not include any other text.\n\n"
+                f"Context:\n{base_prompt}"
+            )
+
+        if mode == "numeric":
+            percentiles: Sequence[int] = kwargs.get("percentiles", (10, 25, 50, 75, 90))
+            if phase == "initial":
+                return (
+                    "You are a professional forecaster preparing a numeric forecast.\n"
+                    "Write a brief, structured rationale only (no percentile lines).\n"
+                    "Include: (1) Units clarified and sanity-checked, (2) plausible min/max constraints,\n"
+                    "(3) status-quo anchor and trend check, (4) distributional shape assumption\n"
+                    "(e.g., symmetric vs. log-normal) and reason, (5) at least one disconfirming scenario.\n"
+                    "Do NOT output lines beginning with 'Percentile'.\n\n"
+                    f"Context:\n{base_prompt}"
+                )
+            # final
+            parts = "\n".join(f"Percentile {p}: XX" for p in percentiles)
+            return (
+                "You are a professional forecaster. Based on the context, output ONLY the following lines, one per percentile, and nothing else:\n"
+                f"{parts}\n\n"
+                "Replace XX with numeric values (no units, no scientific notation).\n"
+                "Always list the percentiles in increasing order.\n\n"
+                f"Context:\n{base_prompt}"
+            )
+
+        # Fallback: return the base prompt (should not happen)
+        return base_prompt
+
+    async def generate(self, prompt: str, mode: str, **kwargs) -> str:  # type: ignore[override]
+        self._ensure_llm()
+        final_prompt = self._wrap_prompt_for_mode(prompt, mode, **kwargs)
+        logger.info(
+            "[Committee][Agent] %s REAL generate() | mode=%s | kwargs=%s",
+            self.name,
+            mode,
+            kwargs,
+        )
+        logger.info(
+            "[Committee][Agent] %s REAL PROMPT (%s):\n%s",
+            self.name,
+            mode,
+            final_prompt,
+        )
+
+        tries = max(1, int(self.allowed_tries or 1))
+        attempt = 0
+        last_error: Exception | None = None
+        while attempt < tries:
+            try:
+                if self._is_gemini_model():
+                    # Run Gemini call without blocking the event loop
+                    response = await asyncio.to_thread(
+                        self._gemini_invoke_blocking, final_prompt
+                    )
+                else:
+                    assert self._llm is not None
+                    # mypy: GeneralLlm has .invoke
+                    response = await getattr(self._llm, "invoke")(final_prompt)  # type: ignore[misc]
+                logger.info(
+                    "[Committee][Agent] %s REAL RESPONSE (%s):\n%s",
+                    self.name,
+                    mode,
+                    response,
+                )
+                return response or ""
+            except Exception as e:  # noqa: BLE001
+                last_error = e
+                attempt += 1
+                logger.warning(
+                    "[Committee][Agent] %s REAL call failed (mode=%s, attempt %s/%s): %s",
+                    self.name,
+                    mode,
+                    attempt,
+                    tries,
+                    e,
+                )
+                if attempt < tries:
+                    # Exponential backoff with jitter
+                    delay = min(8.0, (2 ** (attempt - 1)))
+                    await asyncio.sleep(delay)
+                else:
+                    break
+
+        # Final fallback: deterministic generation to avoid bubbling exceptions
+        logger.error(
+            "[Committee][Agent] %s REAL call exhausted retries (mode=%s). Falling back to deterministic output. Last error: %s",
+            self.name,
+            mode,
+            last_error,
+        )
+        fallback_agent = LLMAgent(name=self.name, weight=self.weight)
+        return await fallback_agent.generate(prompt, mode, **kwargs)
+
+
 def default_agent_committee() -> List[LLMAgent]:
-    """Return a default set of three equal-weight agents."""
-    return [
-        LLMAgent("openrouter/claude-sonnet-4"),
-        LLMAgent("openrouter/gpt-5"),
-        LLMAgent("gemini-2.5-pro"),
+    """Return the default set of agents.
+
+    Behavior:
+    - If ``COMMITTEE_LLM_MODELS`` is set, build REAL agents for those models.
+    - Otherwise, build REAL agents for the default models:
+      ``openrouter/claude-sonnet-4``, ``openrouter/gpt-5``,
+      ``openrouter/claude-opus-4.1``, ``gemini-2.5-flash`` (``gemini-2.5-pro``
+      is also supported if specified via env).
+
+    Tuning env vars (applied in both cases):
+    - ``COMMITTEE_LLM_TEMPERATURE`` (float or empty)
+    - ``COMMITTEE_LLM_TIMEOUT`` (int, default 40)
+    - ``COMMITTEE_LLM_TRIES`` (int, default 2)
+    """
+    models_csv = os.getenv("COMMITTEE_LLM_MODELS")
+
+    # Parse tuning knobs
+    def _parse_float(name: str) -> float | None:
+        v = os.getenv(name)
+        if v is None:
+            return None
+        try:
+            return float(v)
+        except Exception:
+            return None
+
+    def _parse_int(name: str, default: int | None) -> int | None:
+        v = os.getenv(name)
+        if v is None:
+            return default
+        try:
+            return int(v)
+        except Exception:
+            return default
+
+    temperature = _parse_float("COMMITTEE_LLM_TEMPERATURE")
+    timeout = _parse_int("COMMITTEE_LLM_TIMEOUT", 40)
+    tries = _parse_int("COMMITTEE_LLM_TRIES", 2) or 2
+
+    if models_csv:
+        models = [m.strip() for m in models_csv.split(",") if m.strip()]
+        committee: List[LLMAgent] = [
+            RealLLMAgent(
+                name=m,
+                weight=1.0,
+                temperature=temperature,
+                timeout=timeout,
+                allowed_tries=tries,
+            )
+            for m in models
+        ]
+        logger.info(
+            "[Committee] Built REAL agent committee (env): %s",
+            ", ".join(a.name for a in committee),
+        )
+        return committee
+
+    # Default REAL models when env override is not set
+    default_models = [
+        "openrouter/anthropic/claude-sonnet-4",
+        "openrouter/anthropic/claude-opus-4.1",
+        "openrouter/anthropic/claude-opus-4.1",
+        "openrouter/openai/gpt-5",
+        "openrouter/openai/o3-pro",
+        "openrouter/openai/o3-pro",
+        "gemini-2.5-flash",
+        "gemini-2.5-pro",
+        "gemini-2.5-pro",
     ]
+    committee = [
+        RealLLMAgent(
+            name=m,
+            weight=1.0,
+            temperature=temperature,
+            timeout=timeout,
+            allowed_tries=tries,
+        )
+        for m in default_models
+    ]
+    logger.info(
+        "[Committee] Built REAL agent committee (default): %s",
+        ", ".join(a.name for a in committee),
+    )
+    return committee

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,0 +1,48 @@
+"""Entry point for running the multi-agent forecasting system.
+
+This module provides a tiny harness that simulates fetching open questions
+and runs the appropriate forecasting workflow for each.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import List
+
+from .forecaster import forecast_question
+
+# In the real system this would call the Metaculus API.  Here we simply return
+# a small set of example questions of various types.
+
+
+def get_open_question_ids_from_tournament(_tournament_id: int) -> List[dict]:
+    return [
+        {"id": 1, "type": "binary", "text": "Will it rain tomorrow?"},
+        {
+            "id": 2,
+            "type": "multiple_choice",
+            "text": "Who will win the match?",
+            "options": ["Team A", "Team B", "Draw"],
+        },
+        {
+            "id": 3,
+            "type": "numeric",
+            "text": "How many users will sign up next month?",
+            "percentiles": (10, 25, 50, 75, 90),
+        },
+    ]
+
+
+async def forecast_individual_question(question: dict) -> None:
+    result = await forecast_question(question)
+    print(f"Question {question['id']} ({question['type']}): {result}")
+
+
+async def main() -> None:
+    questions = get_open_question_ids_from_tournament(0)
+    tasks = [forecast_individual_question(q) for q in questions]
+    await asyncio.gather(*tasks)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bot/multiple_choice.py
+++ b/bot/multiple_choice.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import List, Sequence
+import logging
 
 import numpy as np
 
@@ -12,49 +13,88 @@ from .search import integrated_research
 from .utils import (
     extract_option_probabilities_from_response,
     normalize_probabilities,
+    today_iso_utc,
 )
 
+logger = logging.getLogger(__name__)
 
 async def get_multiple_choice_forecast(
     question: str, options: Sequence[str], agents: List[LLMAgent]
 ) -> List[float]:
     """Return aggregated probabilities for each option."""
+    logger.info(
+        "[Committee][MC] Starting forecast. Agents=%s | Options=%s | Question='%s'",
+        len(agents),
+        list(options),
+        question,
+    )
+    today = today_iso_utc()
     scope_agent = agents[0]
-    hist = await scope_agent.generate(
-        f"Historical perspective on: {question}", mode="scoping", topic=question
+    # Run scoping prompts concurrently (same content/order preserved)
+    hist_task = asyncio.create_task(
+        scope_agent.generate(
+            f"Date: {today} (UTC)\nHistorical perspective on: {question}",
+            mode="scoping",
+            topic=question,
+        )
     )
-    curr = await scope_agent.generate(
-        f"Current events for: {question}", mode="scoping", topic=question
+    curr_task = asyncio.create_task(
+        scope_agent.generate(
+            f"Date: {today} (UTC)\nCurrent events for: {question}",
+            mode="scoping",
+            topic=question,
+        )
     )
+    hist = await hist_task
+    curr = await curr_task
     queries = hist.splitlines() + curr.splitlines()
+    logger.info("[Committee][MC] Scoped %s queries", len(queries))
+    logger.debug("[Committee][MC] Scoped queries: %s", queries)
     research_context = await integrated_research(queries)
+    logger.info("[Committee][MC] Research context length: %s chars", len(research_context))
 
-    prompt1 = f"Research:\n{research_context}\nQuestion: {question}\nOptions: {options}"
+    prompt1 = (
+        f"Date: {today} (UTC)\nResearch:\n{research_context}\nQuestion: {question}\nOptions: {options}"
+    )
+    logger.debug("[Committee][MC] Initial prompt:\n%s", prompt1)
     initial = await asyncio.gather(
         *[
             agent.generate(
-                prompt1, mode="multiple_choice", n_options=len(options)
+                prompt1,
+                mode="multiple_choice",
+                n_options=len(options),
+                phase="initial",
             )
             for agent in agents
         ]
     )
+    logger.info("[Committee][MC] Initial responses collected: %s", len(initial))
+    logger.debug("[Committee][MC] Initial responses: %s", initial)
     context_map = initial[1:] + initial[:1]
     final = await asyncio.gather(
         *[
             agent.generate(
-                f"Research:\n{research_context}\nPeer analysis:\n{peer}\nQuestion: {question}\nOptions: {options}",
+                f"Date: {today} (UTC)\nResearch:\n{research_context}\nPeer analysis:\n{peer}\nQuestion: {question}\nOptions: {options}",
                 mode="multiple_choice",
                 n_options=len(options),
+                phase="final",
             )
             for agent, peer in zip(agents, context_map)
         ]
     )
+    logger.info("[Committee][MC] Final responses collected: %s", len(final))
+    logger.debug("[Committee][MC] Final responses: %s", final)
     prob_lists = [
         normalize_probabilities(
             extract_option_probabilities_from_response(resp)
         )
         for resp in final
     ]
+    logger.info("[Committee][MC] Extracted per-agent probabilities: %s", prob_lists)
     weights = np.array([a.weight for a in agents])[:, None]
     probs = np.sum(weights * np.array(prob_lists), axis=0) / np.sum(weights)
+    logger.info(
+        "[Committee][MC] Aggregated probabilities per option: %s",
+        {name: round(float(p), 4) for name, p in zip(options, probs.tolist())},
+    )
     return probs.tolist()

--- a/bot/multiple_choice.py
+++ b/bot/multiple_choice.py
@@ -1,0 +1,60 @@
+"""Multiple-choice forecasting workflow."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import List, Sequence
+
+import numpy as np
+
+from .llm_calls import LLMAgent
+from .search import integrated_research
+from .utils import (
+    extract_option_probabilities_from_response,
+    normalize_probabilities,
+)
+
+
+async def get_multiple_choice_forecast(
+    question: str, options: Sequence[str], agents: List[LLMAgent]
+) -> List[float]:
+    """Return aggregated probabilities for each option."""
+    scope_agent = agents[0]
+    hist = await scope_agent.generate(
+        f"Historical perspective on: {question}", mode="scoping", topic=question
+    )
+    curr = await scope_agent.generate(
+        f"Current events for: {question}", mode="scoping", topic=question
+    )
+    queries = hist.splitlines() + curr.splitlines()
+    research_context = await integrated_research(queries)
+
+    prompt1 = f"Research:\n{research_context}\nQuestion: {question}\nOptions: {options}"
+    initial = await asyncio.gather(
+        *[
+            agent.generate(
+                prompt1, mode="multiple_choice", n_options=len(options)
+            )
+            for agent in agents
+        ]
+    )
+    context_map = initial[1:] + initial[:1]
+    final = await asyncio.gather(
+        *[
+            agent.generate(
+                f"Research:\n{research_context}\nPeer analysis:\n{peer}\nQuestion: {question}\nOptions: {options}",
+                mode="multiple_choice",
+                n_options=len(options),
+            )
+            for agent, peer in zip(agents, context_map)
+        ]
+    )
+    prob_lists = [
+        normalize_probabilities(
+            extract_option_probabilities_from_response(resp)
+        )
+        for resp in final
+    ]
+    weights = np.array([a.weight for a in agents])[:, None]
+    probs = np.sum(weights * np.array(prob_lists), axis=0) / np.sum(weights)
+    return probs.tolist()

--- a/bot/numeric.py
+++ b/bot/numeric.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Dict, List, Sequence
+import logging
 
 import numpy as np
 
@@ -12,48 +13,94 @@ from .search import integrated_research
 from .utils import (
     PercentileForecast,
     extract_percentiles_from_response,
+    today_iso_utc,
 )
 
+logger = logging.getLogger(__name__)
 
 async def get_numeric_forecast(
     question: str, percentiles: Sequence[int], agents: List[LLMAgent]
 ) -> List[float]:
     """Return an aggregated 201 point CDF."""
+    logger.info(
+        "[Committee][Numeric] Starting forecast. Agents=%s | Percentiles=%s | Question='%s'",
+        len(agents),
+        list(percentiles),
+        question,
+    )
+    today = today_iso_utc()
     scope_agent = agents[0]
-    hist = await scope_agent.generate(
-        f"Historical perspective on: {question}", mode="scoping", topic=question
+    # Run scoping prompts concurrently (same content/order preserved)
+    hist_task = asyncio.create_task(
+        scope_agent.generate(
+            f"Date: {today} (UTC)\nHistorical perspective on: {question}",
+            mode="scoping",
+            topic=question,
+        )
     )
-    curr = await scope_agent.generate(
-        f"Current events for: {question}", mode="scoping", topic=question
+    curr_task = asyncio.create_task(
+        scope_agent.generate(
+            f"Date: {today} (UTC)\nCurrent events for: {question}",
+            mode="scoping",
+            topic=question,
+        )
     )
+    hist = await hist_task
+    curr = await curr_task
     queries = hist.splitlines() + curr.splitlines()
+    logger.info("[Committee][Numeric] Scoped %s queries", len(queries))
+    logger.debug("[Committee][Numeric] Scoped queries: %s", queries)
     research_context = await integrated_research(queries)
+    logger.info(
+        "[Committee][Numeric] Research context length: %s chars", len(research_context)
+    )
 
-    prompt1 = f"Research:\n{research_context}\nQuestion: {question}"
+    prompt1 = f"Date: {today} (UTC)\nResearch:\n{research_context}\nQuestion: {question}"
+    logger.debug("[Committee][Numeric] Initial prompt:\n%s", prompt1)
     initial = await asyncio.gather(
         *[
-            agent.generate(prompt1, mode="numeric", percentiles=percentiles)
+            agent.generate(
+                prompt1,
+                mode="numeric",
+                percentiles=percentiles,
+                phase="initial",
+            )
             for agent in agents
         ]
     )
+    logger.info("[Committee][Numeric] Initial responses collected: %s", len(initial))
+    logger.debug("[Committee][Numeric] Initial responses: %s", initial)
     context_map = initial[1:] + initial[:1]
     final = await asyncio.gather(
         *[
             agent.generate(
-                f"Research:\n{research_context}\nPeer analysis:\n{peer}\nQuestion: {question}",
+                f"Date: {today} (UTC)\nResearch:\n{research_context}\nPeer analysis:\n{peer}\nQuestion: {question}",
                 mode="numeric",
                 percentiles=percentiles,
+                phase="final",
             )
             for agent, peer in zip(agents, context_map)
         ]
     )
+    logger.info("[Committee][Numeric] Final responses collected: %s", len(final))
+    logger.debug("[Committee][Numeric] Final responses: %s", final)
 
     cdfs: List[List[float]] = []
     for resp in final:
         percentile_values: Dict[int, float] = extract_percentiles_from_response(resp)
+        logger.debug(
+            "[Committee][Numeric] Extracted percentiles from response: %s",
+            percentile_values,
+        )
         forecast = PercentileForecast(percentile_values)
         cdfs.append(forecast.generate_continuous_cdf())
 
     weights = np.array([a.weight for a in agents])[:, None]
     cdf_array = np.sum(weights * np.array(cdfs), axis=0) / np.sum(weights)
+    logger.info(
+        "[Committee][Numeric] Aggregated CDF size: %s (first/last: %.3f, %.3f)",
+        len(cdf_array),
+        float(cdf_array[0]) if len(cdf_array) else float("nan"),
+        float(cdf_array[-1]) if len(cdf_array) else float("nan"),
+    )
     return cdf_array.tolist()

--- a/bot/numeric.py
+++ b/bot/numeric.py
@@ -1,0 +1,59 @@
+"""Numeric question forecasting workflow."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, List, Sequence
+
+import numpy as np
+
+from .llm_calls import LLMAgent
+from .search import integrated_research
+from .utils import (
+    PercentileForecast,
+    extract_percentiles_from_response,
+)
+
+
+async def get_numeric_forecast(
+    question: str, percentiles: Sequence[int], agents: List[LLMAgent]
+) -> List[float]:
+    """Return an aggregated 201 point CDF."""
+    scope_agent = agents[0]
+    hist = await scope_agent.generate(
+        f"Historical perspective on: {question}", mode="scoping", topic=question
+    )
+    curr = await scope_agent.generate(
+        f"Current events for: {question}", mode="scoping", topic=question
+    )
+    queries = hist.splitlines() + curr.splitlines()
+    research_context = await integrated_research(queries)
+
+    prompt1 = f"Research:\n{research_context}\nQuestion: {question}"
+    initial = await asyncio.gather(
+        *[
+            agent.generate(prompt1, mode="numeric", percentiles=percentiles)
+            for agent in agents
+        ]
+    )
+    context_map = initial[1:] + initial[:1]
+    final = await asyncio.gather(
+        *[
+            agent.generate(
+                f"Research:\n{research_context}\nPeer analysis:\n{peer}\nQuestion: {question}",
+                mode="numeric",
+                percentiles=percentiles,
+            )
+            for agent, peer in zip(agents, context_map)
+        ]
+    )
+
+    cdfs: List[List[float]] = []
+    for resp in final:
+        percentile_values: Dict[int, float] = extract_percentiles_from_response(resp)
+        forecast = PercentileForecast(percentile_values)
+        cdfs.append(forecast.generate_continuous_cdf())
+
+    weights = np.array([a.weight for a in agents])[:, None]
+    cdf_array = np.sum(weights * np.array(cdfs), axis=0) / np.sum(weights)
+    return cdf_array.tolist()

--- a/bot/search.py
+++ b/bot/search.py
@@ -1,0 +1,31 @@
+"""Simplified research utilities.
+
+The real system would use AskNews and Gemini search APIs.  Here we simply
+return canned strings describing the queries so that downstream prompts have
+some context to work with.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Iterable, List
+
+
+async def _asknews(query: str) -> str:
+    await asyncio.sleep(0)  # allow context switch
+    return f"AskNews summary for '{query}'"
+
+
+async def _gemini_search(query: str) -> str:
+    await asyncio.sleep(0)
+    return f"Gemini search result for '{query}'"
+
+
+async def integrated_research(queries: Iterable[str]) -> str:
+    """Run AskNews and Gemini search over the provided queries."""
+    tasks: List[asyncio.Task[str]] = []
+    for q in queries:
+        tasks.append(asyncio.create_task(_asknews(q)))
+        tasks.append(asyncio.create_task(_gemini_search(q)))
+    results = await asyncio.gather(*tasks)
+    return "\n".join(results)

--- a/bot/search.py
+++ b/bot/search.py
@@ -1,31 +1,380 @@
-"""Simplified research utilities.
+"""Research utilities used by the committee engine.
 
-The real system would use AskNews and Gemini search APIs.  Here we simply
-return canned strings describing the queries so that downstream prompts have
-some context to work with.
+This now integrates real AskNews lookups (if configured) similar to the
+flow in `fall_template_bot_2025/research.py`. If credentials are not set,
+it falls back to lightweight mocked outputs so the rest of the pipeline
+still functions.
 """
 
 from __future__ import annotations
 
 import asyncio
 from typing import Iterable, List
+import logging
+import os
+import random
+
+from asknews_sdk import AsyncAskNewsSDK
+from gemini_api import gemini_web_search
+from forecasting_tools import GeneralLlm
+
+logger = logging.getLogger(__name__)
 
 
-async def _asknews(query: str) -> str:
-    await asyncio.sleep(0)  # allow context switch
-    return f"AskNews summary for '{query}'"
+def _format_articles(articles) -> str:
+    """Best-effort formatting for AskNews article objects or dicts."""
+    try:
+        sorted_articles = sorted(articles, key=lambda x: x.pub_date, reverse=True)
+    except Exception:
+        try:
+            sorted_articles = sorted(
+                articles, key=lambda x: x.get("pub_date"), reverse=True
+            )
+        except Exception:
+            sorted_articles = articles
+
+    out = ""
+    for article in sorted_articles:
+        try:
+            eng_title = getattr(article, "eng_title", None) or article.get(
+                "eng_title", ""
+            )
+            summary = getattr(article, "summary", None) or article.get("summary", "")
+            language = getattr(article, "language", None) or article.get("language", "")
+            source_id = getattr(article, "source_id", None) or article.get(
+                "source_id", ""
+            )
+            article_url = getattr(article, "article_url", None) or article.get(
+                "article_url", ""
+            )
+            pub_date = getattr(article, "pub_date", None) or article.get("pub_date")
+            if hasattr(pub_date, "strftime"):
+                pub_date_str = pub_date.strftime("%B %d, %Y %I:%M %p")
+            else:
+                pub_date_str = str(pub_date) if pub_date is not None else ""
+        except Exception:
+            eng_title = str(article)
+            summary = ""
+            language = ""
+            source_id = ""
+            article_url = ""
+            pub_date_str = ""
+
+        out += (
+            f"**{eng_title}**\n{summary}\n"
+            f"Original language: {language}\n"
+            f"Publish date: {pub_date_str}\n"
+            f"Source:[{source_id}]({article_url})\n\n"
+        )
+    return out
+
+
+async def _asknews_single_search_formatted(query: str) -> str:
+    """Call AskNews once and format results similarly to the template bot.
+
+    Requires ASKNEWS_CLIENT_ID and ASKNEWS_SECRET. Strategy and n_articles
+    can be controlled with env vars ASKNEWS_STRATEGY and ASKNEWS_N_ARTICLES.
+    """
+    client_id = os.getenv("ASKNEWS_CLIENT_ID")
+    client_secret = os.getenv("ASKNEWS_SECRET")
+    if not client_id or not client_secret:
+        raise ValueError("ASKNEWS_CLIENT_ID or ASKNEWS_SECRET is not set")
+
+    strategy = os.getenv("ASKNEWS_STRATEGY", "news knowledge")
+    try:
+        n_articles = int(os.getenv("ASKNEWS_N_ARTICLES", "10"))
+    except Exception:
+        n_articles = 10
+
+    async with AsyncAskNewsSDK(
+        client_id=client_id, client_secret=client_secret, scopes={"news"}
+    ) as ask:
+        response = await ask.news.search_news(
+            query=query,
+            n_articles=n_articles,
+            return_type="both",
+            strategy=strategy,
+        )
+
+    articles = getattr(response, "as_dicts", None)
+    formatted = "Here are the relevant news articles:\n\n"
+    if articles:
+        formatted += _format_articles(articles)
+    else:
+        formatted += "No articles were found.\n\n"
+    logger.info(
+        "[Committee][AskNews] Query='%s' | Formatted result (%s chars):\n%s",
+        query,
+        len(formatted),
+        formatted,
+    )
+    return formatted
 
 
 async def _gemini_search(query: str) -> str:
-    await asyncio.sleep(0)
-    return f"Gemini search result for '{query}'"
+    """Run a Gemini web search using available API keys with fallbacks.
+
+    Tries env vars `GEMINI_API_KEY_1`, `_2`, `_3` in order. Returns the raw
+    text output. Logs full content for traceability. Falls back to a mocked
+    string if no key is set or all attempts fail.
+    """
+    api_keys = [
+        os.getenv("GEMINI_API_KEY_1"),
+        os.getenv("GEMINI_API_KEY_2"),
+        os.getenv("GEMINI_API_KEY_3"),
+    ]
+    # Retry settings
+    try:
+        max_retries = int(os.getenv("RESEARCH_RETRIES", "2"))
+    except Exception:
+        max_retries = 2
+
+    for i, key in enumerate(api_keys, start=1):
+        if not key:
+            continue
+        attempt = 0
+        while attempt <= max_retries:
+            try:
+                logger.info(
+                    "[Committee][Gemini] Trying web search (key #%s, attempt %s/%s)",
+                    i,
+                    attempt + 1,
+                    max_retries + 1,
+                )
+                response = await asyncio.to_thread(gemini_web_search, query, key)
+                logger.info(
+                    "[Committee][Gemini] Success (key #%s). Result (%s chars)",
+                    i,
+                    len(response),
+                )
+                return response
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "[Committee][Gemini] Search failed (key #%s, attempt %s/%s): %s",
+                    i,
+                    attempt + 1,
+                    max_retries + 1,
+                    e,
+                )
+                attempt += 1
+                if attempt <= max_retries:
+                    # Exponential backoff with jitter
+                    delay = min(8.0, (2 ** (attempt - 1)) + random.random())
+                    await asyncio.sleep(delay)
+                continue
+    # Fallback
+    result = f"[Mock Gemini] search result for '{query}'"
+    logger.warning(
+        "[Committee][Gemini] No API key available or all failed. Using mock. Result: %s",
+        result,
+    )
+    return result
+
+
+async def _gpt4o_search_preview(query: str) -> str:
+    """Run GPT-4o Search (preview) via the same OpenRouter path as llm_calls.
+
+    Uses forecasting_tools.GeneralLlm with model
+    "openrouter/openai/gpt-4o-search-preview". Requires OPENROUTER_API_KEY.
+    Falls back to a mock string if the key is missing or the call fails.
+    """
+    if not os.getenv("OPENROUTER_API_KEY"):
+        result = f"[Mock GPT-4o-Search] search result for '{query}'"
+        logger.warning(
+            "[Committee][GPT-4o-Search] OPENROUTER_API_KEY not set. Using mock. Result: %s",
+            result,
+        )
+        return result
+
+    prompt = (
+        "You are a research assistant. Perform fresh web search and return "
+        "a concise, factual roundup for the following query. Include direct "
+        "citations with titles and URLs.\n\n"
+        f"Query: {query}"
+    )
+
+    # Retry settings
+    try:
+        max_retries = int(os.getenv("RESEARCH_RETRIES", "2"))
+    except Exception:
+        max_retries = 2
+
+    attempt = 0
+    last_error: Exception | None = None
+    while attempt <= max_retries:
+        llm = GeneralLlm(
+            model="openrouter/openai/gpt-4o-search-preview",
+            temperature=None,
+            timeout=40,
+            allowed_tries=2,
+        )
+        try:
+            logger.info(
+                "[Committee][GPT-4o-Search] Invoking GeneralLlm (attempt %s/%s)",
+                attempt + 1,
+                max_retries + 1,
+            )
+            text = await llm.invoke(prompt)  # type: ignore[attr-defined]
+            text = text or "(No text content returned)"
+            logger.info(
+                "[Committee][GPT-4o-Search] Success. Result (%s chars)", len(text)
+            )
+            return text
+        except Exception as e:  # noqa: BLE001
+            last_error = e
+            logger.warning(
+                "[Committee][GPT-4o-Search] Call failed (attempt %s/%s): %s",
+                attempt + 1,
+                max_retries + 1,
+                e,
+            )
+            attempt += 1
+            if attempt <= max_retries:
+                delay = min(8.0, (2 ** (attempt - 1)) + random.random())
+                await asyncio.sleep(delay)
+            continue
+
+    result = (
+        f"[Mock GPT-4o-Search] search result for '{query}'"
+        + (f" (error: {last_error})" if last_error else "")
+    )
+    logger.warning(
+        "[Committee][GPT-4o-Search] All retries failed. Using mock. Error: %s",
+        last_error,
+    )
+    return result
 
 
 async def integrated_research(queries: Iterable[str]) -> str:
-    """Run AskNews and Gemini search over the provided queries."""
-    tasks: List[asyncio.Task[str]] = []
+    """Run AskNews (single-shot), Gemini, and GPT-4o Search.
+
+    Behavior change: AskNews is now called once with a single combined
+    query built from all deduped queries (joined with OR) to use the API
+    sparingly, while Gemini and GPT-4o Search retain per-query calls.
+    """
+    logger.info("[Committee] Starting integrated research over incoming queries")
+    # Realize iterator for logging and reuse
+    if not isinstance(queries, list):
+        queries = list(queries)
+    # Deduplicate and keep order
+    seen = set()
+    deduped: List[str] = []
     for q in queries:
-        tasks.append(asyncio.create_task(_asknews(q)))
-        tasks.append(asyncio.create_task(_gemini_search(q)))
-    results = await asyncio.gather(*tasks)
-    return "\n".join(results)
+        if q not in seen:
+            seen.add(q)
+            deduped.append(q)
+    queries = deduped
+    logger.info("[Committee] Total queries after dedupe: %s", len(queries))
+    logger.debug("[Committee] Queries: %s", queries)
+    client_id = os.getenv("ASKNEWS_CLIENT_ID")
+    client_secret = os.getenv("ASKNEWS_SECRET")
+
+    combined_chunks: List[str] = []
+    if client_id and client_secret:
+        if queries:
+            # Build a single combined AskNews query like: (q1) OR (q2) OR (q3)
+            joiner = os.getenv("ASKNEWS_COMBINE_JOINER", " OR ")
+            parts = []
+            for q in queries:
+                q = (q or "").strip()
+                if not q:
+                    continue
+                if any(ch.isspace() for ch in q):
+                    parts.append(f"({q})")
+                else:
+                    parts.append(q)
+            combined_query = joiner.join(parts) if parts else ""
+            logger.info(
+                "[Committee] Using AskNews (single-shot) over %s queries", len(parts)
+            )
+            try:
+                header = (
+                    f"## AskNews (combined) over {len(parts)} queries\n"
+                    f"Combined query: {combined_query}\n"
+                )
+                chunk = await _asknews_single_search_formatted(combined_query)
+                combined_chunks.append(header + chunk)
+            except Exception as e:
+                logger.warning(
+                    "[Committee] AskNews combined query failed (len=%s): %s",
+                    len(combined_query),
+                    e,
+                )
+        else:
+            logger.info("[Committee] No queries to send to AskNews.")
+    else:
+        logger.warning(
+            "[Committee] ASKNEWS credentials not set. Skipping AskNews (single-shot)."
+        )
+        if queries:
+            combined_chunks.append(
+                f"## AskNews (mock combined) over {len(queries)} queries\nNo articles (mock).\n"
+            )
+
+    # Optional Gemini and GPT-4o Search sections with per-provider concurrency
+    if queries:
+        # Derive provider-specific caps, fall back to a global cap, then default
+        def _cap(env_name: str, fallback_env: str, default_val: int) -> int:
+            try:
+                v = os.getenv(env_name)
+                if v is not None:
+                    return int(v)
+            except Exception:
+                pass
+            try:
+                v2 = os.getenv(fallback_env)
+                if v2 is not None:
+                    return int(v2)
+            except Exception:
+                pass
+            return default_val
+
+        gem_cap = _cap("RESEARCH_GEMINI_MAX_CONCURRENCY", "RESEARCH_MAX_CONCURRENCY", 4)
+        gpt_cap = _cap("RESEARCH_GPT4O_MAX_CONCURRENCY", "RESEARCH_MAX_CONCURRENCY", 4)
+
+        gem_sem = asyncio.Semaphore(gem_cap)
+        gpt_sem = asyncio.Semaphore(gpt_cap)
+
+        async def _with_gem_sem(q: str):
+            async with gem_sem:
+                return await _gemini_search(q)
+
+        async def _with_gpt_sem(q: str):
+            async with gpt_sem:
+                return await _gpt4o_search_preview(q)
+
+        gemini_tasks = [asyncio.create_task(_with_gem_sem(q)) for q in queries]
+        gpt4o_tasks = [asyncio.create_task(_with_gpt_sem(q)) for q in queries]
+
+        gemini_results, gpt4o_results = await asyncio.gather(
+            asyncio.gather(*gemini_tasks), asyncio.gather(*gpt4o_tasks)
+        )
+
+        # Preserve output order by emitting sections in the original sequence
+        for q, gem in zip(queries, gemini_results):
+            chunk = f"## Gemini for query: {q}\n{gem}\n"
+            logger.info(
+                "[Committee][Gemini] Query='%s' | Result (%s chars):\n%s",
+                q,
+                len(chunk),
+                chunk,
+            )
+            combined_chunks.append(chunk)
+
+        for q, gpt4o in zip(queries, gpt4o_results):
+            chunk = f"## GPT-4o Search (preview) for query: {q}\n{gpt4o}\n"
+            logger.info(
+                "[Committee][GPT-4o-Search] Query='%s' | Result (%s chars):\n%s",
+                q,
+                len(chunk),
+                chunk,
+            )
+            combined_chunks.append(chunk)
+
+    combined = "\n".join(combined_chunks)
+    logger.info(
+        "[Committee] Integrated research complete. Sections: %s | Length: %s chars",
+        len(combined_chunks),
+        len(combined),
+    )
+    return combined

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,0 +1,68 @@
+"""Utility functions for the multi-agent forecasting system."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+import numpy as np
+from scipy.interpolate import PchipInterpolator
+
+
+def extract_probability_from_response_as_percentage_not_decimal(text: str) -> float:
+    """Extract a probability expressed as a percentage and return a decimal."""
+    match = re.search(r"([0-9]+(?:\.[0-9]+)?)%", text)
+    if not match:
+        return 0.5
+    return float(match.group(1)) / 100.0
+
+
+def extract_option_probabilities_from_response(text: str) -> List[float]:
+    """Parse a list of probabilities from a string like ``[30%, 40%, 30%]``."""
+    match = re.search(r"\[([^\]]+)\]", text)
+    if not match:
+        return []
+    parts = match.group(1).split(",")
+    probs = []
+    for part in parts:
+        number_match = re.search(r"([0-9]+(?:\.[0-9]+)?)", part)
+        if number_match:
+            probs.append(float(number_match.group(1)) / 100.0)
+    return probs
+
+
+def normalize_probabilities(probs: Iterable[float]) -> List[float]:
+    """Normalize a list of probabilities so they sum to one."""
+    arr = np.array(list(probs), dtype=float)
+    total = arr.sum()
+    if total <= 0:
+        return [1.0 / len(arr)] * len(arr)
+    return list(arr / total)
+
+
+def extract_percentiles_from_response(text: str) -> Dict[int, float]:
+    """Extract ``{percentile: value}`` pairs from lines like ``Percentile 10: 45``."""
+    result: Dict[int, float] = {}
+    for line in text.splitlines():
+        match = re.search(r"(\d+)[a-z]{0,2}\s*[:=]\s*([0-9]+(?:\.[0-9]+)?)", line, re.I)
+        if match:
+            result[int(match.group(1))] = float(match.group(2))
+    return result
+
+
+@dataclass
+class PercentileForecast:
+    percentiles: Dict[int, float]
+
+    def generate_continuous_cdf(self) -> List[float]:
+        """Generate a 201 point monotonic CDF using PCHIP interpolation."""
+        if not self.percentiles:
+            raise ValueError("No percentiles provided")
+        items = sorted(self.percentiles.items())
+        xs = np.array([p / 100.0 for p, _ in items])
+        ys = np.array([v for _, v in items])
+        interpolator = PchipInterpolator(xs, ys, extrapolate=True)
+        grid = np.linspace(0.0, 1.0, 201)
+        values = interpolator(grid)
+        return np.maximum.accumulate(values).tolist()

--- a/main.py
+++ b/main.py
@@ -1,24 +1,53 @@
 import argparse
 import asyncio
 import logging
+import os
+import uuid
+from datetime import datetime
 from typing import Literal
 
 from forecasting_tools import GeneralLlm, MetaculusApi
 from fall_template_bot_2025 import FallTemplateBot2025
+from bot.adapter import CommitteeForecastBot
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    # Configure logging to both console and a uniquely-named file per run
+    logs_dir = "logs"
+    os.makedirs(logs_dir, exist_ok=True)
+    unique_suffix = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{os.getpid()}_{uuid.uuid4().hex[:6]}"
+    log_file_path = os.path.join(logs_dir, f"run_{unique_suffix}.log")
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
+
+    # Console handler
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.INFO)
+    ch.setFormatter(formatter)
+
+    # File handler
+    fh = logging.FileHandler(log_file_path, encoding="utf-8")
+    fh.setLevel(logging.INFO)
+    fh.setFormatter(formatter)
+
+    # Avoid duplicate handlers if re-run in same interpreter
+    root_logger.handlers = []
+    root_logger.addHandler(ch)
+    root_logger.addHandler(fh)
+
+    logging.getLogger(__name__).info("Logging to file: %s", log_file_path)
 
     # Suppress LiteLLM logging
     litellm_logger = logging.getLogger("LiteLLM")
     litellm_logger.setLevel(logging.WARNING)
     litellm_logger.propagate = False
 
-    parser = argparse.ArgumentParser(description="Run the FallTemplateBot2025")
+    parser = argparse.ArgumentParser(description="Run the forecasting bot")
     parser.add_argument(
         "--mode",
         type=str,
@@ -26,38 +55,67 @@ if __name__ == "__main__":
         default="tournament",
         help="Specify the run mode (default: tournament)",
     )
+    parser.add_argument(
+        "--engine",
+        type=str,
+        choices=["template", "committee"],
+        default="committee",
+        help="Choose forecasting engine: 'template' (FallTemplateBot2025) or 'committee' (bot/ adapter)",
+    )
     args = parser.parse_args()
     run_mode: Literal["tournament", "metaculus_cup", "test_questions"] = args.mode
+    engine: Literal["template", "committee"] = args.engine
     assert run_mode in [
         "tournament",
         "metaculus_cup",
         "test_questions",
     ], "Invalid run mode"
-
-    template_bot = FallTemplateBot2025(
-        research_reports_per_question=1,
-        predictions_per_research_report=5,
-        use_research_summary_to_forecast=False,
-        publish_reports_to_metaculus=True,
-        folder_to_save_reports_to=None,
-        skip_previously_forecasted_questions=True,
-        llms={
-            "default": GeneralLlm(
-                model="openrouter/gpt-4.1-mini",
-                temperature=None,
-                timeout=40,
-                allowed_tries=2,
-            ),
-            "summarizer": "openai/gpt-4.1-nano",
-            # "researcher": GeneralLlm(
-            #     model="openrouter/gpt-4o-search-preview",
-            #     temperature=None,
-            #     timeout=40,
-            #     allowed_tries=2,
-            # ),
-            "researcher": "asknews/news-summaries",
-        },
-    )
+    if engine == "template":
+        template_bot = FallTemplateBot2025(
+            research_reports_per_question=1,
+            predictions_per_research_report=5,
+            use_research_summary_to_forecast=False,
+            publish_reports_to_metaculus=True,
+            folder_to_save_reports_to=None,
+            skip_previously_forecasted_questions=True,
+            llms={
+                "default": GeneralLlm(
+                    model="openrouter/gpt-4.1-mini",
+                    temperature=None,
+                    timeout=40,
+                    allowed_tries=2,
+                ),
+                "summarizer": "openai/gpt-4.1-nano",
+                # "researcher": GeneralLlm(
+                #     model="openrouter/gpt-4o-search-preview",
+                #     temperature=None,
+                #     timeout=40,
+                #     allowed_tries=2,
+                # ),
+                "researcher": "asknews/news-summaries",
+            },
+        )
+    else:
+        # CommitteeForecastBot uses local deterministic committee logic; keep posting behavior the same.
+        template_bot = CommitteeForecastBot(
+            research_reports_per_question=1,
+            predictions_per_research_report=1,
+            use_research_summary_to_forecast=False,
+            publish_reports_to_metaculus=True,
+            folder_to_save_reports_to=None,
+            skip_previously_forecasted_questions=True,
+            # LLMs only used for optional summarization; leave defaults minimal.
+            llms={
+                "default": GeneralLlm(
+                    model="openrouter/openai/gpt-4.1-mini",
+                    temperature=None,
+                    timeout=40,
+                    allowed_tries=2,
+                ),
+                "summarizer": "openai/gpt-4.1-nano",
+                "researcher": None,
+            },
+        )
 
     if run_mode == "tournament":
         seasonal_tournament_reports = asyncio.run(
@@ -80,10 +138,11 @@ if __name__ == "__main__":
         )
     elif run_mode == "test_questions":
         EXAMPLE_QUESTIONS = [
-            "https://www.metaculus.com/questions/578/human-extinction-by-2100/",
+            # "https://www.metaculus.com/questions/578/human-extinction-by-2100/",
             # "https://www.metaculus.com/questions/14333/age-of-oldest-human-as-of-2100/",
             # "https://www.metaculus.com/questions/22427/number-of-new-leading-ai-labs/",
             # "https://www.metaculus.com/c/diffusion-community/38880/how-many-us-labor-strikes-due-to-ai-in-2029/",
+            "https://www.metaculus.com/questions/11112/us-military-response-to-invasion-of-taiwan/"
         ]
         template_bot.skip_previously_forecasted_questions = False
         questions = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ openai = "^1.57.4"
 python-dotenv = "^1.0.1"
 forecasting-tools = "^0.2.54"
 google-genai = "^1.30.0"
+scipy = "^1.14.1"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## Summary
- implement simulated multi-agent forecasting workflows for binary, multiple-choice, and numeric questions
- include deterministic LLM agent abstraction, simple research layer, and PCHIP-based numeric CDF generation
- add entry script demonstrating question routing and forecast aggregation

## Testing
- `python -m bot.main`


------
https://chatgpt.com/codex/tasks/task_e_68b097d87bac832aa819b2c2060b5347